### PR TITLE
fix: resolve Invalid regular expression error on macOS (WebKit)

### DIFF
--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -48,8 +48,8 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
 
     // 处理行内代码（避免与代码块冲突）
     html = html.replace(
-      /(?<!`)`([^`\n]+)`(?!`)/g,
-      '<code class="bg-muted px-1.5 py-0.5 rounded text-sm font-mono break-all">$1</code>'
+      /(^|[^`])`([^`\n]+)`([^`]|$)/g,
+      '$1<code class="bg-muted px-1.5 py-0.5 rounded text-sm font-mono break-all">$2</code>$3'
     );
 
     // 处理标题（确保不在代码块内）


### PR DESCRIPTION
### 问题原因
在 macOS 上通过 WebKit 运行应用时，前端正则表达式使用了 WebKit 不兼容的 Lookbehind 语法/命名捕获组，抛出 `SyntaxError: Invalid regular expression: invalid group specifier name` 导致 UI 崩溃。

### 解决方案
- 修改导致错误的正则表达式，改用兼容性更好的匹配写法。
- 在 macOS 10.15+ 上测试验证通过。